### PR TITLE
support laravel ^10

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ["8.0", "8.1"]
-        laravel: ["^8.0", "^9.0"]
+        php: ["8.1", "8.2"]
+        laravel: ["^9.0", "^10.0"]
         stability: ["prefer-lowest", "prefer-stable"]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}

--- a/.php-cs-fixer.laravel.php
+++ b/.php-cs-fixer.laravel.php
@@ -105,7 +105,7 @@ return [
     'short_scalar_cast' => true,
     'simplified_null_return' => true,
     'single_blank_line_at_eof' => true,
-    'single_blank_line_before_namespace' => true,
+    'blank_lines_before_namespace' => true,
     'single_class_element_per_statement' => true,
     'single_import_per_statement' => true,
     'single_line_after_imports' => true,

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/collections": "^8.0 || ^9.0",
-        "illuminate/container": "^8.0 || ^9.0",
-        "illuminate/contracts": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0",
-        "illuminate/translation": "^8.0 || ^9.0",
+        "php": "^8.1",
+        "illuminate/collections": "^9.0 || ^10.0",
+        "illuminate/container": "^9.0 || ^10.0",
+        "illuminate/contracts": "^9.0 || ^10.0",
+        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/translation": "^9.0 || ^10.0",
         "spatie/dns": "^2.0.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^6.25 || ^7.0",
+        "orchestra/testbench": "^7.0 || ^8.0",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-laravel": "^1.3"
     },


### PR DESCRIPTION
Dropped PHP 8.0 support (no longer under active support https://www.php.net/supported-versions.php)
Dropped laravel 8 support.

Probably best to tag as major release due to those changes?
